### PR TITLE
can't read included file while parsing raml in subdir

### DIFF
--- a/test/api/example.html
+++ b/test/api/example.html
@@ -2321,6 +2321,92 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         </div>
                     </div>
                 
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h3 id="_included" class="panel-title">/included</h3>
+                        </div>
+
+                        <div class="panel-body">
+                            
+                                <div class="resource-description">
+                                    <p>an included raml</p>
+
+                                </div>
+                            
+
+                            <div class="panel-group">
+                                <div class="panel panel-white">
+    <div class="panel-heading">
+        <h4 class="panel-title">
+            <a class="block collapsed" data-toggle="collapse" href="#panel__included">
+                
+                    <span class="badge badge_get">get</span>
+                
+                <span class="parent"></span>/included
+            </a>
+        </h4>
+    </div>
+    <div id="panel__included" class="panel-collapse collapse">
+        <div class="panel-body">
+            <div class="list-group">
+                
+                    <a href="#" data-toggle="modal" data-target="#_included_get" class="list-group-item">
+                        <span class="badge badge_get">get</span>
+                        nothing
+                    </a>
+                
+            </div>
+        </div>
+    </div>
+
+    
+        <div class="modal fade" id="_included_get">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title" id="myModalLabel">
+                            <span class="badge badge_get">get</span>
+                            <span class="parent"></span>/included
+                        </h4>
+                    </div>
+                    <div class="modal-body">
+                        <div class="alert alert-info"><p>nothing</p>
+</div>
+
+                        <!-- Nav tabs -->
+                        <ul class="nav nav-tabs">
+                            <li class="active">
+                                <a href="#_included_get_request"data-toggle="tab">Request</a>
+                            </li>
+                            
+                        </ul>
+
+                        <!-- Tab panes -->
+                        <div class="tab-content">
+                            <div class="tab-pane active" id="_included_get_request">
+                                
+
+                                
+
+                                
+                            </div>
+
+                            
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    
+</div>
+
+
+
+                            </div>
+                        </div>
+                    </div>
+                
             </div>
 
             <div class="col-md-3">
@@ -2334,6 +2420,8 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                             <li><a href="#_users">/users</a></li>
                         
                             <li><a href="#_groups">/groups</a></li>
+                        
+                            <li><a href="#_included">/included</a></li>
                         
                     </ul>
                 </div>

--- a/test/api/example.raml
+++ b/test/api/example.raml
@@ -211,3 +211,5 @@ traits:
       /{userId}:
         delete:
           description: Removes a user from a group
+
+/included: !include included.raml

--- a/test/api/included.raml
+++ b/test/api/included.raml
@@ -1,0 +1,4 @@
+description: an included raml
+
+get:
+  description: nothing

--- a/test/gulp-raml2html.js
+++ b/test/gulp-raml2html.js
@@ -117,11 +117,11 @@ describe('gulp-raml2html', function() {
     it('can convert an example RAML file', function(done) {
       var raml2htmlInstance = raml2html();
 
-      var ramlContents = fs.readFileSync(path.join(__dirname, 'example.raml'));
-      var htmlContents = fs.readFileSync(path.join(__dirname, 'example.html'));
+      var ramlContents = fs.readFileSync(path.join(__dirname, 'api/example.raml'));
+      var htmlContents = fs.readFileSync(path.join(__dirname, 'api/example.html'));
 
       raml2htmlInstance.on('data', function(file) {
-        if (file.path === 'example.html') {
+        if (file.path === 'api/example.html') {
           file.isBuffer().should.equal(true);
           file.contents.toString('utf8').should.equal('' + htmlContents);
           done();
@@ -129,7 +129,7 @@ describe('gulp-raml2html', function() {
       });
 
       raml2htmlInstance.write(new File({
-        path: 'example.raml',
+        path: 'api/example.raml',
         contents: ramlContents
       }));
     });


### PR DESCRIPTION
Didn't fix it yet, just modified test to reveal the issue.

CLI `raml2html api/example.raml -o api/example.haml` works.
but test will fail 

``` sh
  1) gulp-raml2html in buffer mode can convert an example RAML file:
     Uncaught Error: api/example.raml:215:12: Parse error while reading included.raml: cannot read included.raml (Error: ENOENT, open 'included.raml')
      at /Users/merlin/workspace/gulp-raml2html/index.js:26:16
      at process._tickCallback (node.js:415:13)
```

As per the [RAML spec](http://raml.org/spec.html)

> If a relative path is used for the included file, the path is interpreted relative to the location of the original (including) file. If the original file is fetched as an HTTP resource, the included file SHOULD be fetched over HTTP.
