### PR TITLE
Update raml2html to ^0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "gulp-util": "^2.2.16",
-    "raml2html": "^0.19.0",
+    "raml2html": "^0.28.0",
     "through2": "^1.0.0"
   },
   "devDependencies": {

--- a/test/example.html
+++ b/test/example.html
@@ -4,6 +4,7 @@
     <title>Example API documentation</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="generator" content="https://github.com/kevinrenskers/raml2html 0.28.0">
 
     <script type="text/javascript">
         var protocol = ((document.location.protocol === 'https:') ? 'https:': 'http:');
@@ -21,9 +22,8 @@
             float: none;
             margin-right: 6px;
         }
-        .panel-title > .block > .badge {
+        .panel-title > .methods {
             float: right;
-            margin-left: 5px;
         }
         .badge {
             border-radius: 0;
@@ -32,12 +32,6 @@
             font-weight: normal;
             color: #f3f3f6;
             line-height: normal;
-        }
-        .block .badge {
-            visibility: hidden;
-        }
-        .block.collapsed .badge {
-            visibility: visible;
         }
         .badge_get {
             background-color: #63a8e2;
@@ -50,9 +44,6 @@
         }
         .badge_delete {
             background-color: #d26460;
-        }
-        .block {
-            display: block;
         }
         .list-group, .panel-group {
             margin-bottom: 0;
@@ -92,11 +83,29 @@
         #sidebar {
             margin-top: 30px;
         }
-        .resource-description {
+        .top-resource-description {
             border-bottom: 1px solid #ddd;
             background: #fcfcfc;
             padding: 15px 15px 0 15px;
             margin: -15px -15px 10px -15px;
+        }
+        .resource-description {
+            border-bottom: 1px solid #fcfcfc;
+            background: #fcfcfc;
+            padding: 15px 15px 0 15px;
+            margin: -15px -15px 10px -15px;
+        }
+        .panel > .panel-body > .panel-group > .panel:first-child .resource-description {
+            display: none;
+        }
+        .list-group .badge {
+            float: left;
+        }
+        .method_description {
+            margin-left: 85px;
+        }
+        .method_description p:last-child {
+            margin: 0;
         }
     </style>
 </head>
@@ -110,12 +119,12 @@
                     <p>http://example.com/1</p>
 
                     
-                        <h3>Welcome</h3>
+                        <h3 id="Welcome"><a href="#Welcome">Welcome</a></h3>
                         <p>Welcome to the Example Documentation. The Example API allows you
 to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                     
-                        <h3>Chapter two</h3>
+                        <h3 id="Chapter-two"><a href="#Chapter-two">Chapter two</a></h3>
                         <p>More content here. Including <strong>bold</strong> text!</p>
 
                     
@@ -129,7 +138,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                         <div class="panel-body">
                             
-                                <div class="resource-description">
+                                <div class="top-resource-description">
                                     <p>This is the top level description for /account.</p>
 <ul>
 <li>One</li>
@@ -144,21 +153,42 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__account">
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__account">
                 <span class="parent"></span>/account
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_account_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__account" class="panel-collapse collapse">
         <div class="panel-body">
+            
+                <div class="resource-description">
+                    <p>This is the top level description for /account.</p>
+<ul>
+<li>One</li>
+<li>Two</li>
+<li>Three</li>
+</ul>
+
+                </div>
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_account_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Creates a new account. Some **bold** text here.
+                        <div class="method_description">
+                            <p>Creates a new account. Some <strong>bold</strong> text here.</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -166,7 +196,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_account_post">
+        <div class="modal fade" tabindex="0" id="_account_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -183,7 +213,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account_post_request"data-toggle="tab">Request</a>
+                                <a href="#_account_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                                 <li>
@@ -200,19 +230,27 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 
 
                                 
+
+                                
                                     <h3>Body</h3>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"john@example.com"</span></span>,
   "<span class="hljs-attribute">password</span>": <span class="hljs-value"><span class="hljs-string">"super_secret"</span></span>,
   "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"John Doe"</span>
 </span>}
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -243,21 +281,32 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__account_find">
-                
-                    <span class="badge badge_get">get</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__account_find">
                 <span class="parent">/account</span>/find
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_account_find_get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__account_find" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_account_find_get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        find an account
+                        <div class="method_description">
+                            <p>find an account</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -265,7 +314,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_account_find_get">
+        <div class="modal fade" tabindex="0" id="_account_find_get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -282,7 +331,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account_find_get_request"data-toggle="tab">Request</a>
+                                <a href="#_account_find_get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -290,6 +339,8 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Tab panes -->
                         <div class="tab-content">
                             <div class="tab-pane active" id="_account_find_get_request">
+                                
+
                                 
 
                                 
@@ -309,12 +360,14 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                                                 <p>name on account</p>
 
+
                                                 
+
                                                 
                                                     <p>
                                                         <small>
-                                                            <strong>Example:</strong>
-                                                            <code>Naruto Uzumaki</code>
+                                                            <strong>Example</strong>:
+                                                            <pre><span class="hljs-title">Naruto</span> Uzumaki</pre>
                                                         </small>
                                                     </p>
                                                 
@@ -330,7 +383,9 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                                 </em>
 
                                                 
+
                                                 
+
                                                 
                                             </li>
                                         
@@ -344,7 +399,9 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                                 </em>
 
                                                 
+
                                                 
+
                                                 
                                             </li>
                                         
@@ -369,35 +426,57 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__account__id_">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_put">put</span>
-                
-                    <span class="badge badge_delete">delete</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__account__id_">
                 <span class="parent">/account</span>/{id}
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_account__id__get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_account__id__put">
+                        <span class="badge badge_put">put</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_account__id__delete">
+                        <span class="badge badge_delete">delete</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__account__id_" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_account__id__get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        
+                        <div class="method_description">
+                            
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_account__id__put" class="list-group-item">
                         <span class="badge badge_put">put</span>
-                        Update the account
+                        <div class="method_description">
+                            <p>Update the account</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_account__id__delete" class="list-group-item">
                         <span class="badge badge_delete">delete</span>
-                        Delete the account
+                        <div class="method_description">
+                            <p>Delete the account</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -405,7 +484,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_account__id__get">
+        <div class="modal fade" tabindex="0" id="_account__id__get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -421,7 +500,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account__id__get_request"data-toggle="tab">Request</a>
+                                <a href="#_account__id__get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -433,9 +512,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>id</strong>: string</li>
+                                            <li>
+                                                <strong>id</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -450,7 +541,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_account__id__put">
+        <div class="modal fade" tabindex="0" id="_account__id__put">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -467,7 +558,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account__id__put_request"data-toggle="tab">Request</a>
+                                <a href="#_account__id__put_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -479,9 +570,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>id</strong>: string</li>
+                                            <li>
+                                                <strong>id</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -496,7 +599,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_account__id__delete">
+        <div class="modal fade" tabindex="0" id="_account__id__delete">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -513,7 +616,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account__id__delete_request"data-toggle="tab">Request</a>
+                                <a href="#_account__id__delete_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -525,9 +628,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>id</strong>: string</li>
+                                            <li>
+                                                <strong>id</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -550,21 +665,32 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__account_login">
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__account_login">
                 <span class="parent">/account</span>/login
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_account_login_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__account_login" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_account_login_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Login with email and password
+                        <div class="method_description">
+                            <p>Login with email and password</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -572,7 +698,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_account_login_post">
+        <div class="modal fade" tabindex="0" id="_account_login_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -589,7 +715,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account_login_post_request"data-toggle="tab">Request</a>
+                                <a href="#_account_login_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                                 <li>
@@ -606,18 +732,26 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 
 
                                 
+
+                                
                                     <h3>Body</h3>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"john@example.com"</span></span>,
   "<span class="hljs-attribute">password</span>": <span class="hljs-value"><span class="hljs-string">"super_secret"</span>
 </span>}
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -658,21 +792,32 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__account_forgot">
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__account_forgot">
                 <span class="parent">/account</span>/forgot
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_account_forgot_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__account_forgot" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_account_forgot_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Sends an email to the user with a link to set a new password
+                        <div class="method_description">
+                            <p>Sends an email to the user with a link to set a new password</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -680,7 +825,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_account_forgot_post">
+        <div class="modal fade" tabindex="0" id="_account_forgot_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -697,7 +842,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account_forgot_post_request"data-toggle="tab">Request</a>
+                                <a href="#_account_forgot_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -710,17 +855,25 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 
 
                                 
+
+                                
                                     <h3>Body</h3>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"john@example.com"</span>
 </span>}
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -741,28 +894,45 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__account_session">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_delete">delete</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__account_session">
                 <span class="parent">/account</span>/session
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_account_session_get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_account_session_delete">
+                        <span class="badge badge_delete">delete</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__account_session" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_account_session_get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Gets the sessions
+                        <div class="method_description">
+                            <p>Gets the sessions</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_account_session_delete" class="list-group-item">
                         <span class="badge badge_delete">delete</span>
-                        Deletes the session, logging out the user
+                        <div class="method_description">
+                            <p>Deletes the session, logging out the user</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -770,7 +940,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_account_session_get">
+        <div class="modal fade" tabindex="0" id="_account_session_get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -787,7 +957,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account_session_get_request"data-toggle="tab">Request</a>
+                                <a href="#_account_session_get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -795,6 +965,8 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Tab panes -->
                         <div class="tab-content">
                             <div class="tab-pane active" id="_account_session_get_request">
+                                
+
                                 
 
                                 
@@ -809,7 +981,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_account_session_delete">
+        <div class="modal fade" tabindex="0" id="_account_session_delete">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -826,7 +998,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_account_session_delete_request"data-toggle="tab">Request</a>
+                                <a href="#_account_session_delete_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -834,6 +1006,8 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Tab panes -->
                         <div class="tab-content">
                             <div class="tab-pane active" id="_account_session_delete_request">
+                                
+
                                 
 
                                 
@@ -865,7 +1039,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                         <div class="panel-body">
                             
-                                <div class="resource-description">
+                                <div class="top-resource-description">
                                     <p>This is the top level description for /conversations.</p>
 
                                 </div>
@@ -875,28 +1049,50 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__conversations">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__conversations">
                 <span class="parent"></span>/conversations
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations_get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__conversations" class="panel-collapse collapse">
         <div class="panel-body">
+            
+                <div class="resource-description">
+                    <p>This is the top level description for /conversations.</p>
+
+                </div>
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations_get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Get a list of conversation for the current user
+                        <div class="method_description">
+                            <p>Get a list of conversation for the current user</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Create a new conversions. The currently logged in user doesn&#x27;t need to be supplied in the members list, it&#x27;s implied.
+                        <div class="method_description">
+                            <p>Create a new conversions. The currently logged in user doesn&#39;t need to be supplied in the members list, it&#39;s implied.</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -904,7 +1100,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_conversations_get">
+        <div class="modal fade" tabindex="0" id="_conversations_get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -921,7 +1117,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations_get_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations_get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -929,6 +1125,8 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Tab panes -->
                         <div class="tab-content">
                             <div class="tab-pane active" id="_conversations_get_request">
+                                
+
                                 
 
                                 
@@ -943,7 +1141,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_conversations_post">
+        <div class="modal fade" tabindex="0" id="_conversations_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -960,7 +1158,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations_post_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                                 <li>
@@ -977,18 +1175,26 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 
 
                                 
+
+                                
                                     <h3>Body</h3>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">content</span>": <span class="hljs-value"><span class="hljs-string">"My message!"</span></span>,
   "<span class="hljs-attribute">members</span>": <span class="hljs-value">[<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]
 </span>}
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -1027,28 +1233,45 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__conversations__convId_">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_put">put</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__conversations__convId_">
                 <span class="parent">/conversations</span>/{convId}
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations__convId__get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations__convId__put">
+                        <span class="badge badge_put">put</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__conversations__convId_" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations__convId__get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Get a single conversation including its messages
+                        <div class="method_description">
+                            <p>Get a single conversation including its messages</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations__convId__put" class="list-group-item">
                         <span class="badge badge_put">put</span>
-                        Update a conversation (change members)
+                        <div class="method_description">
+                            <p>Update a conversation (change members)</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -1056,7 +1279,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_conversations__convId__get">
+        <div class="modal fade" tabindex="0" id="_conversations__convId__get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1073,7 +1296,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations__convId__get_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations__convId__get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1085,9 +1308,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>convId</strong>: string</li>
+                                            <li>
+                                                <strong>convId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1102,7 +1337,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_conversations__convId__put">
+        <div class="modal fade" tabindex="0" id="_conversations__convId__put">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1119,7 +1354,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations__convId__put_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations__convId__put_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1131,9 +1366,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>convId</strong>: string</li>
+                                            <li>
+                                                <strong>convId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1154,28 +1401,45 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__conversations__convId__messages">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__conversations__convId__messages">
                 <span class="parent">/conversations/{convId}</span>/messages
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages_get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__conversations__convId__messages" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages_get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Get the messages for the conversation
+                        <div class="method_description">
+                            <p>Get the messages for the conversation</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Add a new message to a conversation
+                        <div class="method_description">
+                            <p>Add a new message to a conversation</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -1183,7 +1447,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_conversations__convId__messages_get">
+        <div class="modal fade" tabindex="0" id="_conversations__convId__messages_get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1200,7 +1464,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations__convId__messages_get_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations__convId__messages_get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1212,9 +1476,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>convId</strong>: string</li>
+                                            <li>
+                                                <strong>convId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1232,7 +1508,9 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                                                 <p>The number of items per page</p>
 
+
                                                 
+
                                                 
                                             </li>
                                         
@@ -1247,7 +1525,9 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                                                 <p>The page to return</p>
 
+
                                                 
+
                                                 
                                             </li>
                                         
@@ -1264,7 +1544,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_conversations__convId__messages_post">
+        <div class="modal fade" tabindex="0" id="_conversations__convId__messages_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1281,7 +1561,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations__convId__messages_post_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations__convId__messages_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1293,9 +1573,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>convId</strong>: string</li>
+                                            <li>
+                                                <strong>convId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1316,28 +1608,45 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__conversations__convId__messages__messageId_">
-                
-                    <span class="badge badge_put">put</span>
-                
-                    <span class="badge badge_delete">delete</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__conversations__convId__messages__messageId_">
                 <span class="parent">/conversations/{convId}/messages</span>/{messageId}
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages__messageId__put">
+                        <span class="badge badge_put">put</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages__messageId__delete">
+                        <span class="badge badge_delete">delete</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__conversations__convId__messages__messageId_" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages__messageId__put" class="list-group-item">
                         <span class="badge badge_put">put</span>
-                        Update the message
+                        <div class="method_description">
+                            <p>Update the message</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_conversations__convId__messages__messageId__delete" class="list-group-item">
                         <span class="badge badge_delete">delete</span>
-                        Delete the message
+                        <div class="method_description">
+                            <p>Delete the message</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -1345,7 +1654,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_conversations__convId__messages__messageId__put">
+        <div class="modal fade" tabindex="0" id="_conversations__convId__messages__messageId__put">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1362,7 +1671,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations__convId__messages__messageId__put_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations__convId__messages__messageId__put_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1374,11 +1683,33 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>convId</strong>: string</li>
+                                            <li>
+                                                <strong>convId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
-                                            <li><strong>messageId</strong>: string</li>
+                                            <li>
+                                                <strong>messageId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1393,7 +1724,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_conversations__convId__messages__messageId__delete">
+        <div class="modal fade" tabindex="0" id="_conversations__convId__messages__messageId__delete">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1410,7 +1741,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_conversations__convId__messages__messageId__delete_request"data-toggle="tab">Request</a>
+                                <a href="#_conversations__convId__messages__messageId__delete_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1422,11 +1753,33 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>convId</strong>: string</li>
+                                            <li>
+                                                <strong>convId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
-                                            <li><strong>messageId</strong>: string</li>
+                                            <li>
+                                                <strong>messageId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1467,28 +1820,45 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__users">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__users">
                 <span class="parent"></span>/users
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_users_get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_users_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__users" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_users_get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Get a list of all users
+                        <div class="method_description">
+                            <p>Get a list of all users</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_users_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Creates a new user
+                        <div class="method_description">
+                            <p>Creates a new user</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -1496,7 +1866,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_users_get">
+        <div class="modal fade" tabindex="0" id="_users_get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1513,7 +1883,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_users_get_request"data-toggle="tab">Request</a>
+                                <a href="#_users_get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1521,6 +1891,8 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Tab panes -->
                         <div class="tab-content">
                             <div class="tab-pane active" id="_users_get_request">
+                                
+
                                 
 
                                 
@@ -1538,7 +1910,9 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                                                 <p>The number of items per page</p>
 
+
                                                 
+
                                                 
                                             </li>
                                         
@@ -1553,7 +1927,9 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
 
                                                 <p>The page to return</p>
 
+
                                                 
+
                                                 
                                             </li>
                                         
@@ -1570,7 +1946,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_users_post">
+        <div class="modal fade" tabindex="0" id="_users_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1587,7 +1963,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_users_post_request"data-toggle="tab">Request</a>
+                                <a href="#_users_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1600,18 +1976,26 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 
 
                                 
+
+                                
                                     <h3>Body</h3>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">email</span>": <span class="hljs-value"><span class="hljs-string">"john@example.com"</span></span>,
   "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"John Doe"</span></span>,
 }
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -1630,35 +2014,58 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__users__userId_">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_put">put</span>
-                
-                    <span class="badge badge_delete">delete</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__users__userId_">
                 <span class="parent">/users</span>/{userId}
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_users__userId__get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_users__userId__put">
+                        <span class="badge badge_put">put</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_users__userId__delete">
+                        <span class="badge badge_delete">delete</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__users__userId_" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_users__userId__get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Get the details of a user including a list of groups he belongs to
+                        <div class="method_description">
+                            <p>Get the details of a user including a list of groups he belongs to</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_users__userId__put" class="list-group-item">
                         <span class="badge badge_put">put</span>
-                        Update a user
+                        <div class="method_description">
+                            <p>Update a user</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_users__userId__delete" class="list-group-item">
                         <span class="badge badge_delete">delete</span>
-                        Deletes a user
+                        <div class="method_description">
+                            <p>Deletes a user</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -1666,7 +2073,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_users__userId__get">
+        <div class="modal fade" tabindex="0" id="_users__userId__get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1683,7 +2090,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_users__userId__get_request"data-toggle="tab">Request</a>
+                                <a href="#_users__userId__get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1695,9 +2102,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>userId</strong>: string</li>
+                                            <li>
+                                                <strong>userId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1712,7 +2131,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_users__userId__put">
+        <div class="modal fade" tabindex="0" id="_users__userId__put">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1729,7 +2148,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_users__userId__put_request"data-toggle="tab">Request</a>
+                                <a href="#_users__userId__put_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1741,9 +2160,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>userId</strong>: string</li>
+                                            <li>
+                                                <strong>userId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1758,7 +2189,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_users__userId__delete">
+        <div class="modal fade" tabindex="0" id="_users__userId__delete">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1775,7 +2206,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_users__userId__delete_request"data-toggle="tab">Request</a>
+                                <a href="#_users__userId__delete_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1787,9 +2218,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>userId</strong>: string</li>
+                                            <li>
+                                                <strong>userId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -1826,28 +2269,45 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__groups">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__groups">
                 <span class="parent"></span>/groups
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_groups_get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_groups_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__groups" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_groups_get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Get a list of all the groups
+                        <div class="method_description">
+                            <p>Get a list of all the groups</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_groups_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Create a new group
+                        <div class="method_description">
+                            <p>Create a new group</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -1855,7 +2315,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_groups_get">
+        <div class="modal fade" tabindex="0" id="_groups_get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1872,7 +2332,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_groups_get_request"data-toggle="tab">Request</a>
+                                <a href="#_groups_get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1880,6 +2340,8 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Tab panes -->
                         <div class="tab-content">
                             <div class="tab-pane active" id="_groups_get_request">
+                                
+
                                 
 
                                 
@@ -1894,7 +2356,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_groups_post">
+        <div class="modal fade" tabindex="0" id="_groups_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -1911,7 +2373,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_groups_post_request"data-toggle="tab">Request</a>
+                                <a href="#_groups_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -1924,18 +2386,26 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                 
 
                                 
+
+                                
                                     <h3>Body</h3>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Cool people"</span></span>,
   "<span class="hljs-attribute">members</span>": <span class="hljs-value">[<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]
 </span>}
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -1954,35 +2424,58 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__groups__groupId_">
-                
-                    <span class="badge badge_get">get</span>
-                
-                    <span class="badge badge_put">put</span>
-                
-                    <span class="badge badge_delete">delete</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__groups__groupId_">
                 <span class="parent">/groups</span>/{groupId}
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_groups__groupId__get">
+                        <span class="badge badge_get">get</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_groups__groupId__put">
+                        <span class="badge badge_put">put</span>
+                    </a>
+                
+                    <a href="#" data-toggle="modal" data-target="#_groups__groupId__delete">
+                        <span class="badge badge_delete">delete</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__groups__groupId_" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_groups__groupId__get" class="list-group-item">
                         <span class="badge badge_get">get</span>
-                        Get the details of a group, including the member list
+                        <div class="method_description">
+                            <p>Get the details of a group, including the member list</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_groups__groupId__put" class="list-group-item">
                         <span class="badge badge_put">put</span>
-                        Update the group, **optionally** supplying the new list of members (overwrites current list)
+                        <div class="method_description">
+                            <p>Update the group, <strong>optionally</strong> supplying the new list of members (overwrites current list)</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
                     <a href="#" data-toggle="modal" data-target="#_groups__groupId__delete" class="list-group-item">
                         <span class="badge badge_delete">delete</span>
-                        Removes the group
+                        <div class="method_description">
+                            <p>Removes the group</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -1990,7 +2483,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_groups__groupId__get">
+        <div class="modal fade" tabindex="0" id="_groups__groupId__get">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -2007,7 +2500,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_groups__groupId__get_request"data-toggle="tab">Request</a>
+                                <a href="#_groups__groupId__get_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -2019,9 +2512,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>groupId</strong>: string</li>
+                                            <li>
+                                                <strong>groupId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -2036,7 +2541,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_groups__groupId__put">
+        <div class="modal fade" tabindex="0" id="_groups__groupId__put">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -2053,7 +2558,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_groups__groupId__put_request"data-toggle="tab">Request</a>
+                                <a href="#_groups__groupId__put_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -2065,9 +2570,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>groupId</strong>: string</li>
+                                            <li>
+                                                <strong>groupId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -2077,14 +2594,20 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">name</span>": <span class="hljs-value"><span class="hljs-string">"Cool people"</span></span>,
   "<span class="hljs-attribute">members</span>": <span class="hljs-value">[<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-number">3</span>]
 </span>}
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -2097,7 +2620,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
             </div>
         </div>
     
-        <div class="modal fade" id="_groups__groupId__delete">
+        <div class="modal fade" tabindex="0" id="_groups__groupId__delete">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -2114,7 +2637,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_groups__groupId__delete_request"data-toggle="tab">Request</a>
+                                <a href="#_groups__groupId__delete_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -2126,9 +2649,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>groupId</strong>: string</li>
+                                            <li>
+                                                <strong>groupId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -2149,21 +2684,32 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__groups__groupId__users">
-                
-                    <span class="badge badge_post">post</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__groups__groupId__users">
                 <span class="parent">/groups/{groupId}</span>/users
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_groups__groupId__users_post">
+                        <span class="badge badge_post">post</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__groups__groupId__users" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_groups__groupId__users_post" class="list-group-item">
                         <span class="badge badge_post">post</span>
-                        Adds a user to a group
+                        <div class="method_description">
+                            <p>Adds a user to a group</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -2171,7 +2717,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_groups__groupId__users_post">
+        <div class="modal fade" tabindex="0" id="_groups__groupId__users_post">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -2188,7 +2734,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_groups__groupId__users_post_request"data-toggle="tab">Request</a>
+                                <a href="#_groups__groupId__users_post_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -2200,9 +2746,21 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>groupId</strong>: string</li>
+                                            <li>
+                                                <strong>groupId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 
@@ -2212,13 +2770,19 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     
                                         <p><strong>Type: application/json</strong></p>
                                         
+
                                         
+
                                         
-                                            <strong>Example:</strong>
-                                            <pre>{
+                                            <p>
+                                                <small>
+                                                    <strong>Example</strong>:
+                                                    <pre>{
   "<span class="hljs-attribute">user_id</span>": <span class="hljs-value"><span class="hljs-number">4</span></span>,
 }
 </pre>
+                                                </small>
+                                            </p>
                                         
                                     
                                 
@@ -2237,21 +2801,32 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     <div class="panel panel-white">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="block collapsed" data-toggle="collapse" href="#panel__groups__groupId__users__userId_">
-                
-                    <span class="badge badge_delete">delete</span>
-                
+             <a class="collapsed" data-toggle="collapse" href="#panel__groups__groupId__users__userId_">
                 <span class="parent">/groups/{groupId}/users</span>/{userId}
             </a>
+
+            <span class="methods">
+                
+                    <a href="#" data-toggle="modal" data-target="#_groups__groupId__users__userId__delete">
+                        <span class="badge badge_delete">delete</span>
+                    </a>
+                
+            </span>
         </h4>
     </div>
     <div id="panel__groups__groupId__users__userId_" class="panel-collapse collapse">
         <div class="panel-body">
+            
+
             <div class="list-group">
                 
                     <a href="#" data-toggle="modal" data-target="#_groups__groupId__users__userId__delete" class="list-group-item">
                         <span class="badge badge_delete">delete</span>
-                        Removes a user from a group
+                        <div class="method_description">
+                            <p>Removes a user from a group</p>
+
+                        </div>
+                        <div class="clearfix"></div>
                     </a>
                 
             </div>
@@ -2259,7 +2834,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
     </div>
 
     
-        <div class="modal fade" id="_groups__groupId__users__userId__delete">
+        <div class="modal fade" tabindex="0" id="_groups__groupId__users__userId__delete">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -2276,7 +2851,7 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                         <!-- Nav tabs -->
                         <ul class="nav nav-tabs">
                             <li class="active">
-                                <a href="#_groups__groupId__users__userId__delete_request"data-toggle="tab">Request</a>
+                                <a href="#_groups__groupId__users__userId__delete_request" data-toggle="tab">Request</a>
                             </li>
                             
                         </ul>
@@ -2288,11 +2863,33 @@ to do stuff. See also <a href="https://www.example.com">example.com</a>.</p>
                                     <h3>URI Parameters</h3>
                                     <ul>
                                         
-                                            <li><strong>groupId</strong>: string</li>
+                                            <li>
+                                                <strong>groupId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
-                                            <li><strong>userId</strong>: string</li>
+                                            <li>
+                                                <strong>userId</strong>:
+                                                <em>
+                                                    
+                                                        required
+                                                    
+                                                    (string)
+                                                </em>
+
+                                                
+                                            </li>
                                         
                                     </ul>
+                                
+
                                 
 
                                 


### PR DESCRIPTION
The current `raml2html` version is `^0.19.0` which is quite behind the latest.

I updated `example.html` to the actual output from 0.28.0 but it would be better to compare with actual output, not the static file.
