### PR TITLE
Fixes import using relative paths - Fixes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "gulp-util": "^2.2.16",
-    "path": "^0.4.9",
     "raml2html": "^0.19.0",
     "through2": "^1.0.0"
   },


### PR DESCRIPTION
Fixes the issue when raml2html tries to resolve relative path includes in raml files.

According with the grunt file https://github.com/zestia/grunt-contrib-raml2html/blob/master/tasks/raml2html.js
I tried to apply this approach to this plugin.

I didn't perform too much tests but with my current gulp and raml files it's working fine.

If you see whatever issue after testing tell me and we will try to solve them.
